### PR TITLE
quick fix mistake in python assertions

### DIFF
--- a/00-preliminaries/warmup.py
+++ b/00-preliminaries/warmup.py
@@ -21,7 +21,7 @@ x, y = (np.random.randn(100) for _ in range(2))
 def equal(a, b):
   np.testing.assert_array_equal(a, b)
 
-assert(equal(my_mean(x), np.mean(x)))
-assert(equal(my_var(x), np.var(x)))
-assert(equal(my_cov(x, y), np.cov(x, y)))
-assert(equal(my_cor(x, y), np.corrcoef(x, y)))
+equal(my_mean(x), np.mean(x))
+equal(my_var(x), np.var(x))
+equal(my_cov(x, y), np.cov(x, y))
+equal(my_cor(x, y), np.corrcoef(x, y))


### PR DESCRIPTION
The additional "assert"s were redundant (np.testing.assert_array_equal
doesn't return True)
