### PR TITLE
add links to ISLR videos - closes #58

### DIFF
--- a/05-ML_kaggle/README.md
+++ b/05-ML_kaggle/README.md
@@ -51,3 +51,4 @@ Optional:
  * This [interactive visualization](http://www.navan.name/roc/) may help you to gain a better intuitive understanding of ROC curves and area under the curve (AUC).
  * Read [An introduction to ROC analysis](https://ccrma.stanford.edu/workshops/mir2009/references/ROCintro.pdf) for more on area under the ROC curve.
  * Follow along with Wehrley's [soup to nuts kaggle Titanic solution](https://github.com/wehrley/wehrley.github.io/blob/master/SOUPTONUTS.md) which includes a lot of interesting commentary and plots as well. There's plenty on feature generation and dealing with missing data.
+ * Watch the [lecture videos](http://www.dataschool.io/15-hours-of-expert-machine-learning-videos/) from *An Introduction to Statistical Learning* for more on the curse of dimensionality (chapter 2), the bias-variance trade-off (chapter 2), and model evaluation (chapter 5).

--- a/09-linear_R/README.md
+++ b/09-linear_R/README.md
@@ -4,14 +4,8 @@ Read _Chapter 3: Linear Regression_ from [An Introduction to Statistical Learnin
 
 Optional:
 
- * Watch the related videos from the [Statistical Learning course](https://class.stanford.edu/courses/HumanitiesScience/StatLearning/Winter2014/about) taught by the authors of the book:
-   * [Simple Linear Regression](https://www.youtube.com/watch?v=PsE9UqoWtS4) (13:01)
-   * [Hypothesis Testing and Confidence Intervals](https://www.youtube.com/watch?v=J6AdoiNUyWI) (8:24)
-   * [Multiple Linear Regression](https://www.youtube.com/watch?v=1hbCJyM9ccs) (15:37)
-   * [Some Important Questions](https://www.youtube.com/watch?v=3T6RXmIHbJ4) (14:51)
-   * [Extensions of the Linear Model](https://www.youtube.com/watch?v=IFzVxLv0TKQ) (14:16)
-   * [Linear Regression in R](https://www.youtube.com/watch?v=5ONFqIk3RFg) (22:10)
-
+ * Watch the [Chapter 3 lecture videos](http://www.dataschool.io/15-hours-of-expert-machine-learning-videos/) to supplement the reading.
+ 
 
 ### Questions
 

--- a/14-svm/README.md
+++ b/14-svm/README.md
@@ -43,3 +43,4 @@ Optional:
  * Read [A Tutorial on Support Vector Machines for Pattern
 Recognition](https://web.archive.org/web/20120105072605/http://www.umiacs.umd.edu/~joseph/support-vector-machines4.pdf), which includes discussion of VC Dimension.
  * Go through this [tutorial](http://www.louisaslett.com/Courses/Data_Mining/ST4003-Lab7-Introduction_to_Support_Vector_Machines.pdf) on SVMs in `R` using `e1071`.
+ * Watch the [Chapter 9 lecture videos](http://www.dataschool.io/15-hours-of-expert-machine-learning-videos/) from *An Introduction to Statistical Learning* for more on SVMs and a comparison with logistic regression.

--- a/15-clustering/README.md
+++ b/15-clustering/README.md
@@ -55,3 +55,4 @@ Optional:
  * The sklearn documentation has some neat [examples](http://scikit-learn.org/dev/auto_examples/cluster/plot_cluster_comparison.html) demonstrating characteristics of various clustering algorithms.
  * Check out the [sklearn text clustering example](http://scikit-learn.org/dev/auto_examples/document_clustering.html).
  * Read Cloudera's [post](http://blog.cloudera.com/blog/2013/03/cloudera_ml_data_science_tools/) on scaling k-means.
+ * Watch the [Chapter 10 lecture videos](http://www.dataschool.io/15-hours-of-expert-machine-learning-videos/) from *An Introduction to Statistical Learning* to learn about hierarchical clustering.

--- a/16-trees/README.md
+++ b/16-trees/README.md
@@ -39,3 +39,4 @@ Optional:
  * Explore `R` libraries for trees.
      * For CART, see `rpart`. Check out the description at [Quick-R](http://www.statmethods.net/advstats/cart.html).
      * For the well-known tree algorithms of [Quinlan](http://www.rulequest.com/): `RWeka`'s `J48` is C4.5, `C50` has C5.0.
+ * Watch the [Chapter 8 lecture videos](http://www.dataschool.io/15-hours-of-expert-machine-learning-videos/) from *An Introduction to Statistical Learning* for more on decision trees, pruning, and a comparison with linear models.

--- a/17-ensemble/README.md
+++ b/17-ensemble/README.md
@@ -40,3 +40,4 @@ Optional:
  * Check out Jay Hyer's excellent slides on [Ensemble Methods](http://adataheadsdiary.files.wordpress.com/2013/12/dsdc-ensemble-learing.pdf).
  * Check out kaggle's [Getting Started With Random Forests](http://www.kaggle.com/c/titanic-gettingStarted/details/getting-started-with-random-forests).
  * You might look into this [post](http://citizennet.com/blog/2012/11/10/random-forests-ensembles-and-performance-metrics/) about neural nets and random forests, oh my.
+ * Watch the [Chapter 8 lecture videos](http://www.dataschool.io/15-hours-of-expert-machine-learning-videos/) from *An Introduction to Statistical Learning* for more on bagging, boosting, and Random Forests.

--- a/18-dim_reduc/README.md
+++ b/18-dim_reduc/README.md
@@ -5,8 +5,8 @@ Optional:
  * Read [A tutorial on Principal Components Analysis](http://www.cs.otago.ac.nz/cosc453/student_tutorials/principal_components.pdf) for a very friendly introduction that starts from the very basics.
  * Read the [Stanford PCA Tutorial](http://ufldl.stanford.edu/wiki/index.php/PCA), which is just slightly mathier.
  * Read this [step-by-step walk-through](http://sebastianraschka.com/Articles/2014_pca_step_by_step.html) of PCA with Python.
- * Read an excellent paper on [The Fundamental Theorem of Linear Algebra
-](http://home.eng.iastate.edu/~julied/classes/CE570/Notes/strangpaper.pdf) which goes through in an intuitive way just what SVD is all about.
+ * Read an excellent paper on [The Fundamental Theorem of Linear Algebra](http://home.eng.iastate.edu/~julied/classes/CE570/Notes/strangpaper.pdf) which goes through in an intuitive way just what SVD is all about.
+ * Watch the [Chapter 10 lecture videos](http://www.dataschool.io/15-hours-of-expert-machine-learning-videos/) from *An Introduction to Statistical Learning* on PCA.
 
 
 ### Questions


### PR DESCRIPTION
Linking to my blog post instead of individual YouTube videos because:
- The YouTube videos have worthless titles, whereas my post has descriptive video titles
- My post links to the slide decks, so students can browse the video contents to decide whether they want to watch them
- The YouTube videos are unlisted (so you can't browse to see what others are available), whereas on my post you can discover other videos you might like to watch
